### PR TITLE
Add Profile screen to tab bar

### DIFF
--- a/presentation/src/main/kotlin/com/aliasadi/clean/navigation/Page.kt
+++ b/presentation/src/main/kotlin/com/aliasadi/clean/navigation/Page.kt
@@ -13,6 +13,9 @@ sealed class Page {
     data object Favorites : Page()
 
     @Serializable
+    data object Profile : Page()
+
+    @Serializable
     data object Search : Page()
 
     @Serializable

--- a/presentation/src/main/kotlin/com/aliasadi/clean/ui/navigationbar/NavigationBarNestedGraph.kt
+++ b/presentation/src/main/kotlin/com/aliasadi/clean/ui/navigationbar/NavigationBarNestedGraph.kt
@@ -9,6 +9,7 @@ import com.aliasadi.clean.ui.favorites.FavoritesPage
 import com.aliasadi.clean.ui.favorites.FavoritesViewModel
 import com.aliasadi.clean.ui.feed.FeedPage
 import com.aliasadi.clean.ui.feed.FeedViewModel
+import com.aliasadi.clean.ui.profile.ProfilePage
 import com.aliasadi.clean.ui.main.MainRouter
 import com.aliasadi.clean.util.composableHorizontalSlide
 import com.aliasadi.clean.util.sharedViewModel
@@ -39,6 +40,9 @@ fun NavigationBarNestedGraph(
                 mainRouter = MainRouter(mainNavController),
                 viewModel = viewModel,
             )
+        }
+        composableHorizontalSlide<Page.Profile> {
+            ProfilePage()
         }
     }
 }

--- a/presentation/src/main/kotlin/com/aliasadi/clean/ui/navigationbar/NavigationBarUiState.kt
+++ b/presentation/src/main/kotlin/com/aliasadi/clean/ui/navigationbar/NavigationBarUiState.kt
@@ -3,13 +3,15 @@ package com.aliasadi.clean.ui.navigationbar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DynamicFeed
 import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.aliasadi.clean.navigation.Page
 
 data class NavigationBarUiState(
     val bottomItems: List<BottomNavigationBarItem> = listOf(
         BottomNavigationBarItem.Feed,
-        BottomNavigationBarItem.MyFavorites
+        BottomNavigationBarItem.MyFavorites,
+        BottomNavigationBarItem.Profile
     )
 )
 
@@ -20,4 +22,5 @@ sealed class BottomNavigationBarItem(
 ) {
     data object Feed : BottomNavigationBarItem("Feed", imageVector = Icons.Default.DynamicFeed, Page.Feed)
     data object MyFavorites : BottomNavigationBarItem("My Favorites", imageVector = Icons.Default.FavoriteBorder, Page.Favorites)
+    data object Profile : BottomNavigationBarItem("Profile", imageVector = Icons.Default.Person, Page.Profile)
 }

--- a/presentation/src/main/kotlin/com/aliasadi/clean/ui/profile/ProfileScreen.kt
+++ b/presentation/src/main/kotlin/com/aliasadi/clean/ui/profile/ProfileScreen.kt
@@ -1,0 +1,45 @@
+package com.aliasadi.clean.ui.profile
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.aliasadi.clean.R
+import com.aliasadi.clean.util.preview.PreviewContainer
+
+@Composable
+fun ProfilePage() {
+    Surface {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(text = stringResource(id = R.string.user_name))
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(text = stringResource(id = R.string.user_email))
+        }
+    }
+}
+
+@Preview(name = "Light")
+@Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun ProfilePagePreview() {
+    PreviewContainer {
+        ProfilePage()
+    }
+}

--- a/presentation/src/main/kotlin/com/aliasadi/clean/ui/profile/ProfileScreen.kt
+++ b/presentation/src/main/kotlin/com/aliasadi/clean/ui/profile/ProfileScreen.kt
@@ -5,8 +5,15 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material3.Icon
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -24,13 +31,40 @@ fun ProfilePage() {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(16.dp),
+                .padding(24.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
+            verticalArrangement = Arrangement.Top
         ) {
-            Text(text = stringResource(id = R.string.user_name))
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(text = stringResource(id = R.string.user_email))
+            Icon(
+                imageVector = Icons.Default.AccountCircle,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(96.dp)
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = stringResource(id = R.string.user_name),
+                style = MaterialTheme.typography.titleLarge
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = stringResource(id = R.string.user_email),
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+            FilledTonalButton(
+                onClick = {},
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(text = stringResource(id = R.string.edit_profile))
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            OutlinedButton(
+                onClick = {},
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(text = stringResource(id = R.string.sign_out))
+            }
         }
     }
 }

--- a/presentation/src/main/kotlin/com/aliasadi/clean/ui/widget/BottomNavigationBar.kt
+++ b/presentation/src/main/kotlin/com/aliasadi/clean/ui/widget/BottomNavigationBar.kt
@@ -44,6 +44,6 @@ fun BottomNavigationBar(
 @Composable
 private fun BottomNavigationBarViewPreview() {
     PreviewContainer {
-        BottomNavigationBar(listOf(Feed, MyFavorites), rememberNavController()) {}
+        BottomNavigationBar(listOf(Feed, MyFavorites, Profile), rememberNavController()) {}
     }
 }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -3,6 +3,9 @@
     <string name="clean_architecture">Clean Architecture</string>
     <string name="feed">Feed</string>
     <string name="favorites">Favorites</string>
+    <string name="profile">Profile</string>
+    <string name="user_name">John Doe</string>
+    <string name="user_email">john@example.com</string>
     <string name="movie_details_placeholder_text">Click on a movie\n to view its details.</string>
     <string name="search">Search</string>
     <string name="no_search_results_title">No Results Found</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -6,6 +6,8 @@
     <string name="profile">Profile</string>
     <string name="user_name">John Doe</string>
     <string name="user_email">john@example.com</string>
+    <string name="edit_profile">Edit profile</string>
+    <string name="sign_out">Sign out</string>
     <string name="movie_details_placeholder_text">Click on a movie\n to view its details.</string>
     <string name="search">Search</string>
     <string name="no_search_results_title">No Results Found</string>


### PR DESCRIPTION
## Summary
- add Profile strings
- create Profile page composable
- register Profile page in navigation enum and bottom bar
- include Profile in nested graph and bar previews

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684002f9cec4832db5498efc166febf0